### PR TITLE
Disable use of the --no-debug if desired

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -67,7 +67,12 @@ start "Installing Dependencies"
   crystal deps --production
 finished
 
-NO_DEBUG_IF_AVAILABLE=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`
+NO_DEBUG_IF_AVAILABLE=""
+
+# Compile with --no-debug if supported unless the DEBUG_ENABLE var is set
+if [[ !-n DEBUG_ENABLED ]]; then
+  NO_DEBUG_IF_AVAILABLE=`crystal build --help | grep -q -- --no-debug && echo -n --no-debug`
+fi
 
 if [ -f app.cr ]; then
   start "Compiling app.cr (using old behaviour, app.cr exists - ignoring shard.yml)"


### PR DESCRIPTION
Compile the application without the --no-debug flag if the DEBUG_ENABLED env variable is set, making debugging optional.